### PR TITLE
Add GitLab versions 11 and 10.X for testing

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   gitlab:
     restart: always
-    image: sameersbn/gitlab:10.2.5
+    image: sameersbn/gitlab:${GITLAB_VERSION}
     depends_on:
     - redis
     - postgresql

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,15 +1,27 @@
 #!/bin/bash 
 set -eu
 PKG_LIST=$1
-pushd ci
-docker-compose up -d
 
-until curl -sSf http://localhost:10080/users/sign_in  > /dev/null
-do
-  sleep 10
+versions=( \
+  10.2.5 \
+  10.8.4 \
+  11.0.2 \
+)
+
+for version in "${versions[@]}"; do
+  pushd ci
+  printf "Testing with GitLab $version\n\n"
+  GITLAB_VERSION=${version} docker-compose up -d
+  until curl -sSf http://localhost:10080/explore  > /dev/null
+  do
+    sleep 10
+  done
+  popd
+  printf "Testing...\n\n"
+  go test -v -covermode=count -coverprofile=profile.cov -timeout=1200s ${PKG_LIST}
+  pushd ci
+  printf "Teardown...\n\n"
+  GITLAB_VERSION=${version} docker-compose down -v --rmi 'local'
+  popd
 done
-popd 
-go test -v -covermode=count -coverprofile=profile.cov -timeout=1200s ${PKG_LIST}
-pushd ci
-docker-compose down -v
-popd
+


### PR DESCRIPTION
This will update the testing steps to be more compliant to the latest version of GitLab.

Signed-off-by: solidnerd <niclas@mietz.io>